### PR TITLE
use write_all to support s3 writer

### DIFF
--- a/src/mips_emulator/state.rs
+++ b/src/mips_emulator/state.rs
@@ -960,8 +960,9 @@ impl InstrumentedState {
             };
             let name = format!("{output}/{}", self.pre_segment_id);
             log::trace!("split: file {}", name);
-            let f = new_writer(&name).unwrap();
-            serde_json::to_writer(f, &segment).unwrap();
+            let mut f = new_writer(&name).unwrap();
+            let data = serde_json::to_vec(&segment).unwrap();
+            f.write_all(data.as_slice()).unwrap();
             self.pre_segment_id += 1;
         }
 


### PR DESCRIPTION
serde_json::to_writer will write one or two bytes each time until all data are writed succeed, which is unacceptable for file system like s3. So I use write_all to replace to write all data into file.