### PR TITLE
Switch to use mips-zkm-zkvm-elf toolchain

### DIFF
--- a/build/src/command/local.rs
+++ b/build/src/command/local.rs
@@ -27,9 +27,7 @@ pub(crate) fn create_local_command(
     //    toolchain.
     command
         .current_dir(canonicalized_program_dir)
-        .env("RUSTUP_TOOLCHAIN", "nightly-2023-04-06")
         .env("CARGO_ENCODED_RUSTFLAGS", get_rust_compiler_flags())
-        .env_remove("RUSTC")
         .env(
             "CARGO_TARGET_DIR",
             program_metadata.target_directory.join(HELPER_TARGET_SUBDIR),

--- a/build/src/command/utils.rs
+++ b/build/src/command/utils.rs
@@ -45,13 +45,17 @@ pub(crate) fn get_program_build_args(args: &BuildArgs) -> Vec<String> {
 pub(crate) fn get_rust_compiler_flags() -> String {
     let rust_flags = [
         "-C".to_string(),
-        "target-cpu=mips32".to_string(),
-        "--cfg".to_string(),
-        "target_os=\"zkvm\"".to_string(),
+        "target-cpu=mips2".to_string(),
         "-C".to_string(),
         "target-feature=+crt-static".to_string(),
         "-C".to_string(),
+        "link-arg=-nostdlib".to_string(),
+        "-C".to_string(),
         "link-arg=-g".to_string(),
+        //"-C".to_string(),
+        //"link-arg=-nostartfiles".to_string(),
+        "-C".to_string(),
+        "link-arg=--entry=main".to_string(),
     ];
     rust_flags.join("\x1f")
 }

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -6,7 +6,7 @@ pub use build::execute_build_program;
 
 use clap::Parser;
 
-const BUILD_TARGET: &str = "mips-unknown-linux-musl";
+const BUILD_TARGET: &str = "mips-zkm-zkvm-elf";
 // const DEFAULT_TAG: &str = "v1.0.0";
 const DEFAULT_OUTPUT_DIR: &str = "elf";
 const HELPER_TARGET_SUBDIR: &str = "elf-compilation";

--- a/prover/examples/revme/host/src/main.rs
+++ b/prover/examples/revme/host/src/main.rs
@@ -215,7 +215,7 @@ fn prove_multi_seg_common(
     result
 }
 
-const ELF_PATH: &str = "../guest/elf/mips-unknown-linux-musl";
+const ELF_PATH: &str = "../guest/elf/mips-zkm-zkvm-elf";
 
 fn prove_revm() {
     // 1. split ELF into segs

--- a/prover/examples/sha2-precompile/host/src/main.rs
+++ b/prover/examples/sha2-precompile/host/src/main.rs
@@ -20,7 +20,7 @@ const D: usize = 2;
 type C = PoseidonGoldilocksConfig;
 type F = <C as GenericConfig<D>>::F;
 
-const ELF_PATH: &str = "../guest/elf/mips-unknown-linux-musl";
+const ELF_PATH: &str = "../guest/elf/mips-zkm-zkvm-elf";
 
 fn u32_array_to_u8_vec(u32_array: &[u32; 8]) -> Vec<u8> {
     let mut u8_vec = Vec::with_capacity(u32_array.len() * 4);

--- a/prover/examples/sha2-rust/host/src/main.rs
+++ b/prover/examples/sha2-rust/host/src/main.rs
@@ -214,7 +214,7 @@ fn prove_multi_seg_common(
     result
 }
 
-const ELF_PATH: &str = "../guest/elf/mips-unknown-linux-musl";
+const ELF_PATH: &str = "../guest/elf/mips-zkm-zkvm-elf";
 
 fn prove_sha2_rust() {
     // 1. split ELF into segs


### PR DESCRIPTION
So that we don't need mips-linux-musl toolchain again.
It will be much easy to use.

Howto use:
```
1. Download toolchain from https://github.com/zkMIPS/toolchain/releases
2. Unpack the toolchain, and set your PATH env
3. cd prover/examples/sha2-rust/host
4. ARGS='711e9609339e92b03ddc0a211827dba421f38f9ed8b9d806e1ffdd8c15ffa03d world!' \
        RUST_LOG=info SEG_OUTPUT=/tmp/output \
        cargo run --release
```