### PR TITLE
chore: change keccak256 to precompiled keccak in revme

### DIFF
--- a/prover/examples/revme/guest/Cargo.lock
+++ b/prover/examples/revme/guest/Cargo.lock
@@ -325,7 +325,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "zkm-runtime",
+ "zkm-runtime 0.2.0",
 ]
 
 [[package]]
@@ -472,7 +472,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 [[package]]
 name = "models"
 version = "0.1.0"
-source = "git+https://github.com/eigmax/powdr-revme?branch=continuations#0abf75bce415b9f713dcc86a034bf6977b984583"
+source = "git+https://github.com/zkMIPS/powdr-revme?branch=continuations#91da508810e9371a5cf7c241c40836a92ab59e0f"
 dependencies = [
  "revm",
  "serde",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.5.0"
-source = "git+https://github.com/powdr-labs/revm?branch=serde-no-std#8653c72bfd70cbac061b03d0c0de02153dbc6601"
+source = "git+https://github.com/zkMIPS/revm?branch=serde-no-std#e56ca8cf19f35ffa05c0e701d9b5d9fc1e48c70d"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.3.0"
-source = "git+https://github.com/powdr-labs/revm?branch=serde-no-std#8653c72bfd70cbac061b03d0c0de02153dbc6601"
+source = "git+https://github.com/zkMIPS/revm?branch=serde-no-std#e56ca8cf19f35ffa05c0e701d9b5d9fc1e48c70d"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.2.0"
-source = "git+https://github.com/powdr-labs/revm?branch=serde-no-std#8653c72bfd70cbac061b03d0c0de02153dbc6601"
+source = "git+https://github.com/zkMIPS/revm?branch=serde-no-std#e56ca8cf19f35ffa05c0e701d9b5d9fc1e48c70d"
 dependencies = [
  "aurora-engine-modexp",
  "k256",
@@ -693,17 +693,19 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.3.0"
-source = "git+https://github.com/powdr-labs/revm?branch=serde-no-std#8653c72bfd70cbac061b03d0c0de02153dbc6601"
+source = "git+https://github.com/zkMIPS/revm?branch=serde-no-std#e56ca8cf19f35ffa05c0e701d9b5d9fc1e48c70d"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
  "bitflags",
  "bitvec",
  "c-kzg",
+ "cfg-if",
  "enumn",
  "hashbrown",
  "hex",
  "serde",
+ "zkm-runtime 0.2.0 (git+https://github.com/zkMIPS/zkm)",
 ]
 
 [[package]]
@@ -1002,6 +1004,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zkm-precompiles"
+version = "0.2.0"
+source = "git+https://github.com/zkMIPS/zkm#461635650582a575338a7b8bb96dcf3861e0cc0a"
+dependencies = [
+ "bincode",
+ "cfg-if",
+ "serde",
+ "sha2",
+]
+
+[[package]]
 name = "zkm-runtime"
 version = "0.2.0"
 dependencies = [
@@ -1013,5 +1026,21 @@ dependencies = [
  "rand",
  "serde",
  "sha2",
- "zkm-precompiles",
+ "zkm-precompiles 0.2.0",
+]
+
+[[package]]
+name = "zkm-runtime"
+version = "0.2.0"
+source = "git+https://github.com/zkMIPS/zkm#461635650582a575338a7b8bb96dcf3861e0cc0a"
+dependencies = [
+ "bincode",
+ "cfg-if",
+ "getrandom",
+ "lazy_static",
+ "libm",
+ "rand",
+ "serde",
+ "sha2",
+ "zkm-precompiles 0.2.0 (git+https://github.com/zkMIPS/zkm)",
 ]

--- a/prover/examples/revme/guest/Cargo.toml
+++ b/prover/examples/revme/guest/Cargo.toml
@@ -10,10 +10,8 @@ edition = "2021"
 
 [dependencies]
 zkm-runtime = { path = "../../../../runtime/entrypoint" }
-revm = { git = "https://github.com/powdr-labs/revm", branch = "serde-no-std", default-features = false, features = [ "serde" ] }
-
-#models = { path = "../models" }
-models = { git = "https://github.com/eigmax/powdr-revme", branch = "continuations", package = "models" }
+revm = { git = "https://github.com/zkMIPS/revm", branch = "serde-no-std", default-features = false, features = [ "serde" ] }
+models = { git = "https://github.com/zkMIPS/powdr-revme", branch = "continuations", package = "models" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 k256 = { version = "0.13.3", features = ["ecdsa"], default-features = false }

--- a/prover/examples/revme/guest/src/main.rs
+++ b/prover/examples/revme/guest/src/main.rs
@@ -4,7 +4,7 @@
 use revm::{
     db::CacheState,
     interpreter::CreateScheme,
-    primitives::{calc_excess_blob_gas, keccak256, Bytecode, Env, SpecId, TransactTo, U256},
+    primitives::{calc_excess_blob_gas, Bytecode, Env, SpecId, TransactTo, U256, B256},
     Evm,
 };
 extern crate libc;
@@ -47,8 +47,7 @@ fn execute_test_suite(suite: TestSuite) -> Result<(), String> {
         let mut cache_state = CacheState::new(false);
         for (address, info) in unit.pre {
             let acc_info = revm::primitives::AccountInfo {
-                balance: info.balance,
-                code_hash: keccak256(&info.code),
+                balance: info.balance, code_hash: B256::from(zkm_runtime::io::keccak(&info.code)),
                 code: Some(Bytecode::new_raw(info.code)),
                 nonce: info.nonce,
             };


### PR DESCRIPTION
This optimization helps reduce the size of the tables, which are the total cells we commit. Therefore,  it reduces the total proving time.

Here are the metrics before this opt:
![Screenshot from 2025-01-11 20-36-48](https://github.com/user-attachments/assets/85f915ee-9c73-4ded-b6df-fff82b245594)
As you can see, the total number of committed cells is up to 2*10^8 and the proving time is ~ 170s

After this optimization, the number of committed cells decreases to ~ 1.5 * 10^8 ( **25% reduction** ), and the proving is reduced to 143s
![Screenshot from 2025-01-11 20-37-44](https://github.com/user-attachments/assets/d42beaf2-80b8-4ea1-a133-0cf9f685fe5d)
  